### PR TITLE
Suggest alternate way of describing the CMG

### DIFF
--- a/package-versions/grouping-and-overrides/multi-targeting.md
+++ b/package-versions/grouping-and-overrides/multi-targeting.md
@@ -74,3 +74,13 @@ During a build targeting .NET Framework 4.7.2, `foo` will be imported with versi
 During a build targeting .NET Core 3.1, `foo` will be imported with version 3.3.3.
 
 During a build targeting .NET Framework 4.7.2, `foo` will be imported with version 4.4.4.
+
+Alternatively this could be simplifed as below so that changing the TFM would surface the need to revisit the groups:
+
+```xml
+<Project>
+  <ItemGroup>
+    <PackageReference Include="foo" CentralManagementGroup="A$(TargetFramework)" />
+  </ItemGroup>
+</Project>
+```


### PR DESCRIPTION
I'm not suggesting the edit I've made is here is actually merged, but I'm using it as a way to raise a discussion point.

The way the example is written, it could be alternately expressed by using the TFM to build the group's name.

A possible advantage of authoring it this way would be that when adding a new TFM (e.g. `net5.0`), the build would fail because `Anet5.0` is not a defined CMG, rather than silently choose to use the global CMG.